### PR TITLE
Pausing based on level timer

### DIFF
--- a/mudrunner.asl
+++ b/mudrunner.asl
@@ -1,6 +1,7 @@
 state("MudRunner")
 {
 	float levelTimer : 0xB99020; // Time after loaded in (but seems to get reset sometimes?)
+	float actualLevelTimer : 0xBA40BC; //Time whitch was played on a map, pesistent even after loading a game
 	float globalTimer : 0xBA4A60; // Total time since loading game
 	bool finished : 0xB990AC; // Have all the logs on the current level been delivered?
 	bool paused : 0xB99EFD; // Is the pause screen open?
@@ -37,5 +38,5 @@ update
 
 isLoading 
 {
-    return current.paused;
+    return current.paused || current.actualLevelTimer == old.actualLevelTimer;
 }


### PR DESCRIPTION
In my test splitter i figured that we should pause the timer always if the level timer is paused, so only real ingame time will be counted.
Please note that i used the other level timer because "levelTimer" will pause if you are in the game map.